### PR TITLE
Streamed CAGRA Index Build Support

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -380,6 +380,7 @@ if(BUILD_SHARED_LIBS)
     src/neighbors/cagra_build_half.cu
     src/neighbors/cagra_build_int8.cu
     src/neighbors/cagra_build_uint8.cu
+    src/neighbors/cagra_streaming_build.cu
     src/neighbors/cagra_extend_float.cu
     src/neighbors/cagra_extend_int8.cu
     src/neighbors/cagra_extend_uint8.cu

--- a/cpp/include/cuvs/neighbors/cagra_streaming_build.hpp
+++ b/cpp/include/cuvs/neighbors/cagra_streaming_build.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <cuvs/neighbors/cagra.hpp>
+#include <cuvs/neighbors/ivf_pq.hpp>
+#include <raft/core/device_mdspan.hpp>
+#include <raft/core/host_device_accessor.hpp>
+#include <raft/core/host_mdspan.hpp>
+#include <raft/core/mdspan.hpp>
+#include <raft/core/mdspan_types.hpp>
+
+namespace cuvs::neighbors {
+template <typename T, typename IdxT>
+class cagra_streaming_build {
+ public:
+  cagra_streaming_build()  = default;
+  ~cagra_streaming_build() = default;
+
+  cagra_streaming_build(raft::resources const& res,
+                        int64_t num_vectors,
+                        int64_t dims,
+                        int64_t num_sample_batch,
+                        int64_t max_batch_size,
+                        cuvs::neighbors::cagra::index_params const& params,
+                        bool ivf_pq_build_using_device_buffer = true);
+
+  void process_batch(raft::resources const& res,
+                     cuvs::neighbors::cagra::index_params const& params,
+                     raft::host_matrix_view<const T, int64_t, raft::row_major> dataset,
+                     bool sample_batch,
+                     bool add_sample_batch_to_graph);
+
+  auto finalize_graph(raft::resources const& res,
+                      cuvs::neighbors::cagra::index_params const& params)
+    -> cuvs::neighbors::cagra::index<T, IdxT>;
+
+ private:
+  void ivf_pq_search_helper(raft::resources const& res,
+                            raft::host_matrix_view<const T, int64_t> dataset_view);
+
+  int64_t num_vectors_;
+  int64_t dims_;
+  int64_t num_sample_batch_;
+  int64_t max_batch_size_;
+
+  int64_t sample_batch_processed_;
+  int64_t curr_sample_data_size_;
+  int64_t curr_graph_data_size_;
+  int64_t knn_graph_index_;
+
+  int64_t intermediate_degree_;
+  int64_t graph_degree_;
+
+  // Parameters to for CAGRA and IVF-PQ.
+  cuvs::neighbors::cagra::index_params cagra_params_;
+
+  // Temporary device buffers.
+  std::optional<raft::host_matrix<IdxT, int64_t>> knn_graph_;
+
+  std::vector<const T*> graph_data_batch_ptrs_;
+  std::vector<int64_t> graph_data_batch_sizes_;
+  bool device_buffer_for_ivf_build_;
+
+  // Device and host staging buffers for IVF-PQ index build. Only one is used based on user input.
+  raft::device_matrix<T, int64_t, raft::row_major> ivf_pq_build_dataset_dev_;
+  raft::host_matrix<T, int64_t, raft::row_major> ivf_pq_build_dataset_host_;
+  bool ivf_pq_build_using_device_buffer_;
+
+  raft::host_vector<int64_t, int64_t, raft::row_major> extend_indices_;
+
+  cuvs::neighbors::ivf_pq::index<int64_t> ivf_pq_index_;
+  cuvs::neighbors::cagra::graph_build_params::ivf_pq_params ivf_pq_params_;
+
+  int64_t top_k_;
+  int64_t gpu_top_k_;
+
+  using extents = std::experimental::extents<int64_t, raft::dynamic_extent, raft::dynamic_extent>;
+
+  raft::device_mdarray<float, extents, raft::row_major> distances_;
+  raft::device_mdarray<int64_t, extents, raft::row_major> neighbors_;
+  raft::host_matrix<int64_t, int64_t, raft::row_major> neighbors_host_;
+  raft::host_matrix<T, int64_t, raft::row_major> queries_host_;
+
+  uint32_t kMaxQueries_;
+  bool ivf_index_built_;
+};
+
+extern template class cagra_streaming_build<float, uint32_t>;
+extern template class cagra_streaming_build<uint8_t, uint32_t>;
+}  // namespace cuvs::neighbors

--- a/cpp/include/cuvs/neighbors/cagra_streaming_build.hpp
+++ b/cpp/include/cuvs/neighbors/cagra_streaming_build.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include <cuvs/neighbors/cagra.hpp>

--- a/cpp/src/neighbors/cagra_streaming_build.cu
+++ b/cpp/src/neighbors/cagra_streaming_build.cu
@@ -1,0 +1,422 @@
+#include "cagra.cuh"
+#include <cuvs/neighbors/cagra.hpp>
+#include <cuvs/neighbors/cagra_streaming_build.hpp>
+#include <iostream>
+#include <raft/common/nvtx.hpp>
+
+#include "./detail/cagra/cagra_build.cuh"
+#include "./ivf_pq/ivf_pq_build.cuh"
+#include "./ivf_pq/ivf_pq_search.cuh"
+
+namespace cuvs::neighbors {
+
+template <typename T, typename IdxT>
+cagra_streaming_build<T, IdxT>::cagra_streaming_build(
+  raft::resources const& res,
+  int64_t num_vectors,
+  int64_t dims,
+  int64_t num_sample_batch,
+  int64_t max_batch_size,
+  cuvs::neighbors::cagra::index_params const& params,
+  bool ivf_pq_build_using_device_buffer)
+  : num_vectors_(num_vectors),
+    dims_(dims),
+    num_sample_batch_(num_sample_batch),
+    max_batch_size_(max_batch_size),
+    knn_graph_(res),
+    ivf_pq_build_dataset_dev_(res),
+    ivf_pq_build_dataset_host_(res),
+    ivf_pq_index_(res),
+    extend_indices_(res),
+    distances_(res),
+    neighbors_(res),
+    neighbors_host_(res),
+    queries_host_(res),
+    ivf_index_built_(false)
+{
+  raft::common::nvtx::range<cuvs::common::nvtx::domain::cuvs> fun_scope("cagra_streaming_build");
+  cagra_params_ = params;
+
+  intermediate_degree_ = cagra_params_.intermediate_graph_degree;
+  graph_degree_        = cagra_params_.graph_degree;
+
+  // TODO: we are suppose to check if the intermediate_graph_degree is larger than dataset size.
+  if (intermediate_degree_ < graph_degree_) {
+    RAFT_LOG_WARN(
+      "Graph degree (%lu) cannot be larger than intermediate graph degree (%lu), reducing "
+      "graph_degree.",
+      graph_degree_,
+      intermediate_degree_);
+    graph_degree_ = intermediate_degree_;
+  }
+
+  if (cagra_params_.attach_dataset_on_build == true) {
+    RAFT_LOG_WARN(
+      "CAGRA streaming build does not support attaching dataset on build. Forcing to not attach "
+      "dataset.");
+    cagra_params_.attach_dataset_on_build = false;
+  }
+
+  extend_indices_                   = raft::make_host_vector<int64_t, int64_t>(max_batch_size);
+  ivf_pq_build_using_device_buffer_ = ivf_pq_build_using_device_buffer;
+  auto knn_build_params             = cagra_params_.graph_build_params;
+  if (ivf_pq_build_using_device_buffer_) {
+    ivf_pq_build_dataset_dev_ =
+      raft::make_device_matrix<T, int64_t>(res, num_sample_batch_ * max_batch_size_, dims_);
+    if (!std::holds_alternative<cagra::graph_build_params::ivf_pq_params>(knn_build_params)) {
+      RAFT_LOG_INFO(
+        "Build parameter is not defined or is not defined as IVF-PQ build. Forcing using IVF-PQ "
+        "parameters");
+      knn_build_params = cagra::graph_build_params::ivf_pq_params(
+        ivf_pq_build_dataset_dev_.extents(), cagra_params_.metric);
+    }
+  } else {
+    ivf_pq_build_dataset_host_ =
+      raft::make_host_matrix<T, int64_t>(num_sample_batch_ * max_batch_size_, dims_);
+    if (!std::holds_alternative<cagra::graph_build_params::ivf_pq_params>(knn_build_params)) {
+      RAFT_LOG_INFO(
+        "Build parameter is not defined or is not defined as IVF-PQ build. Forcing using IVF-PQ "
+        "parameters");
+      knn_build_params = cagra::graph_build_params::ivf_pq_params(
+        ivf_pq_build_dataset_host_.extents(), cagra_params_.metric);
+    }
+  }
+  // Allocate KNN graph.
+  knn_graph_.emplace(raft::make_host_matrix<IdxT, int64_t>(num_vectors_, intermediate_degree_));
+
+  ivf_pq_params_ =
+    std::get<cuvs::neighbors::cagra::graph_build_params::ivf_pq_params>(knn_build_params);
+  if (ivf_pq_params_.refinement_rate != 1) {
+    RAFT_LOG_WARN(
+      "CAGRA streaming build does not support refinement for IVF-PQ KNN construction. Forcing to "
+      "not using refinement.");
+    ivf_pq_params_.refinement_rate = 1;
+  }
+  if (ivf_pq_params_.build_params.kmeans_trainset_fraction != 1.0) {
+    RAFT_LOG_WARN(
+      "CAGRA streaming build disables user's control on kmeans_trainset_fraction. Instead all data "
+      "points in sampled chunks are used for IVF-PQ KNN construction.");
+    ivf_pq_params_.build_params.kmeans_trainset_fraction = 1.0;
+  }
+  if (ivf_pq_params_.build_params.add_data_on_build) {
+    RAFT_LOG_WARN(
+      "CAGRA streaming build requires disabling adding data for IVF-PQ KNN construction. Forcing "
+      "to not add data to IVF-PQ index.");
+    ivf_pq_params_.build_params.add_data_on_build = false;
+  }
+
+  top_k_     = intermediate_degree_ + 1;
+  gpu_top_k_ = top_k_;  // refinement cannot be not enabled, so set gpu_top_k_ = top_k_.
+  // Use the same maximum batch size as the ivf_pq::search to avoid allocating more than needed.
+  using cuvs::neighbors::ivf_pq::detail::kMaxQueries;
+  kMaxQueries_ = kMaxQueries;
+
+  // Heuristic: the build_knn_graph code should use only a fraction of the workspace memory; the
+  // rest should be used by the ivf_pq::search. Here we say that the workspace size should be a good
+  // multiple of what is required for the I/O batching below.
+  constexpr size_t kMinWorkspaceRatio = 5;
+  auto desired_workspace_size         = kMaxQueries_ * kMinWorkspaceRatio *
+                                (sizeof(T) * dims_           // queries (dataset batch)
+                                 + sizeof(float) * gpu_top_k_    // distances_
+                                 + sizeof(int64_t) * gpu_top_k_  // neighbors
+                                );
+
+  // If the workspace is smaller than desired, put the I/O buffers into the large workspace.
+  rmm::device_async_resource_ref workspace_mr =
+    desired_workspace_size <= raft::resource::get_workspace_free_bytes(res)
+      ? raft::resource::get_workspace_resource(res)
+      : raft::resource::get_large_workspace_resource(res);
+
+  RAFT_LOG_DEBUG(
+    "IVF-PQ search node_degree: %d, top_k_: %d,  gpu_top_k_: %d,  max_batch_size:: %d, n_probes: "
+    "%u",
+    node_degree,
+    top_k_,
+    gpu_top_k_,
+    kMaxQueries,
+    pq.search_params.n_probes);
+
+  // Temporary buffers for IVF-PQ search.
+  distances_ = raft::make_device_mdarray<float>(
+    res, workspace_mr, raft::make_extents<int64_t>(kMaxQueries_, gpu_top_k_));
+  neighbors_ = raft::make_device_mdarray<int64_t>(
+    res, workspace_mr, raft::make_extents<int64_t>(kMaxQueries_, gpu_top_k_));
+  neighbors_host_ = raft::make_host_matrix<int64_t, int64_t>(kMaxQueries_, gpu_top_k_);
+  queries_host_   = raft::make_host_matrix<T, int64_t>(kMaxQueries_, dims_);
+
+  sample_batch_processed_ = 0;
+  curr_sample_data_size_  = 0;
+  curr_graph_data_size_   = 0;
+  knn_graph_index_        = 0;
+}
+
+// This helper function was borrowed from CAGRA::build implementation. Code related to refinement
+// was removed for simplicity.
+template <typename T, typename IdxT>
+void cagra_streaming_build<T, IdxT>::ivf_pq_search_helper(
+  raft::resources const& res, raft::host_matrix_view<const T, int64_t> dataset_view)
+{
+  raft::common::nvtx::range<cuvs::common::nvtx::domain::cuvs> fun_scope("ivf_pq_search_helper");
+  auto dataset = raft::host_mdspan<const T, raft::matrix_extent<int64_t>, raft::row_major>(
+    dataset_view.data_handle(), dataset_view.extent(0), dataset_view.extent(1));
+
+  const auto num_queries = dataset.extent(0);
+
+  // Copied directly from CAGRA build implementation.
+  // TODO(tfeher): batched search with multiple GPUs
+  std::size_t num_self_included = 0;
+  const auto start_clock        = std::chrono::system_clock::now();
+
+  cuvs::spatial::knn::detail::utils::batch_load_iterator<T> vec_batches(
+    dataset.data_handle(),
+    dataset.extent(0),
+    dataset.extent(1),
+    static_cast<int64_t>(kMaxQueries_),
+    raft::resource::get_cuda_stream(res),
+    raft::resource::get_workspace_resource(res));
+
+  size_t next_report_offset = 0;
+  size_t d_report_offset    = dataset.extent(0) / 100;  // Report progress in 1% steps.
+
+  size_t previous_batch_size   = 0;
+  size_t previous_batch_offset = 0;
+
+  for (const auto& batch : vec_batches) {
+    // Map int64_t to uint32_t because ivf_pq requires the latter.
+    // TODO(tfeher): remove this mapping once ivf_pq accepts mdspan with int64_t index type
+    auto queries_view = raft::make_device_matrix_view<const T, uint32_t>(
+      batch.data(), batch.size(), batch.row_width());
+    auto neighbors_view = raft::make_device_matrix_view<int64_t, uint32_t>(
+      neighbors_.data_handle(), batch.size(), neighbors_.extent(1));
+    auto distances_view = raft::make_device_matrix_view<float, uint32_t>(
+      distances_.data_handle(), batch.size(), distances_.extent(1));
+    cuvs::neighbors::ivf_pq::search(res,
+                                    ivf_pq_params_.search_params,
+                                    ivf_pq_index_,
+                                    queries_view,
+                                    neighbors_view,
+                                    distances_view);
+
+    auto curr_knn_graph_view = raft::make_host_matrix_view<IdxT, int64_t>(
+      knn_graph_->data_handle(), knn_graph_->extent(0), knn_graph_->extent(1));
+
+    // process previous batch async on host
+    // NOTE: the async path also covers disabled refinement (top_k_ == gpu_top_k__)
+    if (previous_batch_size > 0) {
+      cuvs::neighbors::cagra::detail::write_to_graph(curr_knn_graph_view,
+                                                     neighbors_host_.view(),
+                                                     num_self_included,
+                                                     previous_batch_size,
+                                                     previous_batch_offset + knn_graph_index_);
+    }
+
+    // copy next batch to host
+    raft::copy(neighbors_host_.data_handle(),
+               neighbors_.data_handle(),
+               neighbors_view.size(),
+               raft::resource::get_cuda_stream(res));
+
+    previous_batch_size   = batch.size();
+    previous_batch_offset = batch.offset();
+
+    // we need to ensure the copy operations are done prior using the host data
+    raft::resource::sync_stream(res);
+
+    // process last batch
+    if (previous_batch_offset + previous_batch_size == (size_t)num_queries) {
+      cuvs::neighbors::cagra::detail::write_to_graph(curr_knn_graph_view,
+                                                     neighbors_host_.view(),
+                                                     num_self_included,
+                                                     previous_batch_size,
+                                                     previous_batch_offset + knn_graph_index_);
+    }
+
+    size_t num_queries_done = batch.offset() + batch.size();
+    const auto end_clock    = std::chrono::system_clock::now();
+    if (batch.offset() > next_report_offset) {
+      next_report_offset += d_report_offset;
+      const auto time =
+        std::chrono::duration_cast<std::chrono::microseconds>(end_clock - start_clock).count() *
+        1e-6;
+      const auto throughput = num_queries_done / time;
+
+      RAFT_LOG_DEBUG(
+        "# Search %12lu / %12lu (%3.2f %%), %e queries/sec, %.2f minutes ETA, self included = "
+        "%3.2f %%    \r",
+        num_queries_done,
+        dataset.extent(0),
+        num_queries_done / static_cast<double>(dataset.extent(0)) * 100,
+        throughput,
+        (num_queries - num_queries_done) / throughput / 60,
+        static_cast<double>(num_self_included) / num_queries_done * 100.);
+    }
+  }
+  RAFT_LOG_DEBUG("# Finished building kNN graph for current chunk");
+}
+
+template <typename T, typename IdxT>
+void cagra_streaming_build<T, IdxT>::process_batch(
+  raft::resources const& res,
+  cuvs::neighbors::cagra::index_params const& params,
+  raft::host_matrix_view<const T, int64_t, raft::row_major> dataset,
+  bool sample_batch,
+  bool add_sample_batch_to_graph)
+{
+  raft::common::nvtx::range<cuvs::common::nvtx::domain::cuvs> fun_scope("process_batch");
+  int64_t batch_size  = dataset.extent(0);
+  int64_t batch_dim   = dataset.extent(1);
+  const T* batch_data = dataset.data_handle();
+
+  RAFT_EXPECTS(batch_dim == dims_,
+               "Dimensionality of the batch data should be the same as provided in the setup call");
+  RAFT_EXPECTS(batch_size <= max_batch_size_,
+               "The size for the dataset should be smaller than batch size");
+
+  if (sample_batch) {
+    // Copy the current batch to the staging buffer (either on device or on host) for IVF-PQ index
+    // build.
+    if (sample_batch_processed_ < num_sample_batch_) {
+      if (ivf_pq_build_using_device_buffer_) {
+        raft::copy(ivf_pq_build_dataset_dev_.data_handle() + curr_sample_data_size_ * dims_,
+                   batch_data,
+                   batch_size * dims_,
+                   raft::resource::get_cuda_stream(res));
+      } else {
+        raft::copy(ivf_pq_build_dataset_host_.data_handle() + curr_sample_data_size_ * dims_,
+                   batch_data,
+                   batch_size * dims_,
+                   raft::resource::get_cuda_stream(res));
+      }
+      curr_sample_data_size_ += batch_size;
+    }
+    sample_batch_processed_++;
+    // If the batch is going to be added to the graph, store the pointer to access the batch later.
+    if (add_sample_batch_to_graph) {
+      graph_data_batch_ptrs_.push_back(batch_data);
+      graph_data_batch_sizes_.push_back(batch_size);
+    }
+    // All sampled batches are received, start to build IVF-PQ index.
+    if (sample_batch_processed_ == num_sample_batch_ && !ivf_index_built_) {
+      // Build index using ivf_pq_build_dataset.
+      if (ivf_pq_build_using_device_buffer_) {
+        const std::string model_name = [&]() {
+          char model_name[1024];
+          sprintf(model_name,
+                  "%s-%lux%lu.cluster_%u.pq_%u.%ubit.itr_%u.metric_%u.pqcenter_%u",
+                  "IVF-PQ",
+                  static_cast<size_t>(ivf_pq_build_dataset_dev_.extent(0)),
+                  static_cast<size_t>(ivf_pq_build_dataset_dev_.extent(1)),
+                  ivf_pq_params_.build_params.n_lists,
+                  ivf_pq_params_.build_params.pq_dim,
+                  ivf_pq_params_.build_params.pq_bits,
+                  ivf_pq_params_.build_params.kmeans_n_iters,
+                  ivf_pq_params_.build_params.metric,
+                  static_cast<uint32_t>(ivf_pq_params_.build_params.codebook_kind));
+          return std::string(model_name);
+        }();
+        RAFT_LOG_DEBUG("# Building IVF-PQ index %s", model_name.c_str());
+        auto ivf_pq_build_mdspan =
+          raft::device_mdspan<const T, raft::matrix_extent<int64_t>, raft::row_major>(
+            ivf_pq_build_dataset_dev_.data_handle(), curr_sample_data_size_, dims_);
+        ivf_pq_index_ = cuvs::neighbors::ivf_pq::detail::build<T, int64_t>(
+          res, ivf_pq_params_.build_params, ivf_pq_build_mdspan);
+      } else {
+        const std::string model_name = [&]() {
+          char model_name[1024];
+          sprintf(model_name,
+                  "%s-%lux%lu.cluster_%u.pq_%u.%ubit.itr_%u.metric_%u.pqcenter_%u",
+                  "IVF-PQ",
+                  static_cast<size_t>(ivf_pq_build_dataset_host_.extent(0)),
+                  static_cast<size_t>(ivf_pq_build_dataset_host_.extent(1)),
+                  ivf_pq_params_.build_params.n_lists,
+                  ivf_pq_params_.build_params.pq_dim,
+                  ivf_pq_params_.build_params.pq_bits,
+                  ivf_pq_params_.build_params.kmeans_n_iters,
+                  ivf_pq_params_.build_params.metric,
+                  static_cast<uint32_t>(ivf_pq_params_.build_params.codebook_kind));
+          return std::string(model_name);
+        }();
+        RAFT_LOG_DEBUG("# Building IVF-PQ index %s", model_name.c_str());
+        auto ivf_pq_build_mdspan =
+          raft::host_mdspan<const T, raft::matrix_extent<int64_t>, raft::row_major>(
+            ivf_pq_build_dataset_host_.data_handle(), curr_sample_data_size_, dims_);
+        ivf_pq_index_ = cuvs::neighbors::ivf_pq::detail::build<T, int64_t>(
+          res, ivf_pq_params_.build_params, ivf_pq_build_mdspan);
+      }
+      ivf_index_built_ = true;
+
+      // Adding previous received batches that are going to be stored in the CAGRA graph to the
+      // IVF-PQ index.
+      for (size_t i = 0; i < graph_data_batch_ptrs_.size(); i++) {
+        // Assign indices in the CAGRA graph for each data point.
+        std::iota(extend_indices_.data_handle(),
+                  extend_indices_.data_handle() + graph_data_batch_sizes_[i],
+                  curr_graph_data_size_);
+        curr_graph_data_size_ += graph_data_batch_sizes_[i];
+        auto curr_batch_view = raft::make_host_matrix_view<const T, int64_t>(
+          graph_data_batch_ptrs_[i], graph_data_batch_sizes_[i], dims_);
+        auto extend_indices_view = raft::make_host_vector_view<int64_t, int64_t>(
+          extend_indices_.data_handle(), graph_data_batch_sizes_[i]);
+        cuvs::neighbors::ivf_pq::extend(res, curr_batch_view, extend_indices_view, &ivf_pq_index_);
+      }
+    }
+  } else {
+    // For non-sampled batches, store the pointer for later access and add data to the IVF-PQ index
+    // if available.
+    graph_data_batch_ptrs_.push_back(batch_data);
+    graph_data_batch_sizes_.push_back(batch_size);
+
+    if (!ivf_index_built_) { return; }
+    std::iota(extend_indices_.data_handle(),
+              extend_indices_.data_handle() + batch_size,
+              curr_graph_data_size_);
+    auto extend_indices_view =
+      raft::make_host_vector_view<int64_t, int64_t>(extend_indices_.data_handle(), batch_size);
+    curr_graph_data_size_ += batch_size;
+    cuvs::neighbors::ivf_pq::extend(res, dataset, extend_indices_view, &ivf_pq_index_);
+  }
+
+  raft::resource::sync_stream(res);
+  return;
+}
+
+template <typename T, typename IdxT>
+auto cagra_streaming_build<T, IdxT>::finalize_graph(
+  raft::resources const& res, cuvs::neighbors::cagra::index_params const& params)
+  -> cuvs::neighbors::cagra::index<T, IdxT>
+{
+  raft::common::nvtx::range<cuvs::common::nvtx::domain::cuvs> fun_scope("finalize_graph");
+  // KNN graph construction through IVF-PQ search. Refinement must be disabled since there is no
+  // contiguous dataset available.
+  for (size_t i = 0; i < graph_data_batch_ptrs_.size(); i++) {
+    auto curr_data_batch = raft::make_host_matrix_view<const T, int64_t>(
+      graph_data_batch_ptrs_[i], graph_data_batch_sizes_[i], dims_);
+    ivf_pq_search_helper(res, curr_data_batch);
+    knn_graph_index_ += graph_data_batch_sizes_[i];
+  }
+
+  auto cagra_graph = raft::make_host_matrix<IdxT, int64_t>(num_vectors_, graph_degree_);
+
+  RAFT_LOG_INFO("optimizing graph");
+  cuvs::neighbors::cagra::detail::optimize<IdxT>(
+    res, knn_graph_->view(), cagra_graph.view(), params.guarantee_connectivity);
+
+  // Free intermediate graph before trying to create the index
+  knn_graph_.reset();
+
+  RAFT_LOG_INFO("Graph optimized, creating index");
+
+  RAFT_EXPECTS(params.attach_dataset_on_build == false,
+               "Dataset cannot be inserted using streaming build");
+  RAFT_EXPECTS(params.compression.has_value() == false,
+               "Compression is not supported using streaming build");
+
+  cuvs::neighbors::cagra::index<T, IdxT> idx(res);
+  // Return CAGRA graph to the user.
+  idx.update_graph(res, raft::make_const_mdspan(cagra_graph.view()));
+  return idx;
+}
+
+template class cagra_streaming_build<float, uint32_t>;
+template class cagra_streaming_build<uint8_t, uint32_t>;
+}  // namespace cuvs::neighbors

--- a/cpp/src/neighbors/cagra_streaming_build.cu
+++ b/cpp/src/neighbors/cagra_streaming_build.cu
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "cagra.cuh"
 #include <cuvs/neighbors/cagra.hpp>
 #include <cuvs/neighbors/cagra_streaming_build.hpp>
@@ -116,7 +132,7 @@ cagra_streaming_build<T, IdxT>::cagra_streaming_build(
   // multiple of what is required for the I/O batching below.
   constexpr size_t kMinWorkspaceRatio = 5;
   auto desired_workspace_size         = kMaxQueries_ * kMinWorkspaceRatio *
-                                (sizeof(T) * dims_           // queries (dataset batch)
+                                (sizeof(T) * dims_               // queries (dataset batch)
                                  + sizeof(float) * gpu_top_k_    // distances_
                                  + sizeof(int64_t) * gpu_top_k_  // neighbors
                                 );

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -36,6 +36,7 @@ set(BUILD_CUVS_C_LIBRARY OFF)
 include(../cmake/thirdparty/get_cuvs.cmake)
 
 # -------------- compile tasks ----------------- #
+add_executable(STREAMING_CAGRA_EXAMPLE src/streaming_cagra_example.cu)
 add_executable(CAGRA_EXAMPLE src/cagra_example.cu)
 add_executable(CAGRA_PERSISTENT_EXAMPLE src/cagra_persistent_example.cu)
 add_executable(DYNAMIC_BATCHING_EXAMPLE src/dynamic_batching_example.cu)
@@ -48,13 +49,26 @@ add_executable(VAMANA_EXAMPLE src/vamana_example.cu)
 add_library(rmm_logger OBJECT)
 target_link_libraries(rmm_logger PRIVATE rmm::rmm_logger_impl)
 
-target_link_libraries(CAGRA_EXAMPLE PRIVATE cuvs::cuvs $<TARGET_NAME_IF_EXISTS:conda_env> rmm_logger)
 target_link_libraries(
-  CAGRA_PERSISTENT_EXAMPLE PRIVATE cuvs::cuvs $<TARGET_NAME_IF_EXISTS:conda_env> Threads::Threads rmm_logger
+  STREAMING_CAGRA_EXAMPLE PRIVATE cuvs::cuvs $<TARGET_NAME_IF_EXISTS:conda_env> rmm_logger
 )
 target_link_libraries(
-  DYNAMIC_BATCHING_EXAMPLE PRIVATE cuvs::cuvs $<TARGET_NAME_IF_EXISTS:conda_env> Threads::Threads rmm_logger
+  CAGRA_EXAMPLE PRIVATE cuvs::cuvs $<TARGET_NAME_IF_EXISTS:conda_env> rmm_logger
 )
-target_link_libraries(IVF_PQ_EXAMPLE PRIVATE cuvs::cuvs $<TARGET_NAME_IF_EXISTS:conda_env> rmm_logger)
-target_link_libraries(IVF_FLAT_EXAMPLE PRIVATE cuvs::cuvs $<TARGET_NAME_IF_EXISTS:conda_env> rmm_logger)
-target_link_libraries(VAMANA_EXAMPLE PRIVATE cuvs::cuvs $<TARGET_NAME_IF_EXISTS:conda_env> rmm_logger)
+target_link_libraries(
+  CAGRA_PERSISTENT_EXAMPLE PRIVATE cuvs::cuvs $<TARGET_NAME_IF_EXISTS:conda_env> Threads::Threads
+                                   rmm_logger
+)
+target_link_libraries(
+  DYNAMIC_BATCHING_EXAMPLE PRIVATE cuvs::cuvs $<TARGET_NAME_IF_EXISTS:conda_env> Threads::Threads
+                                   rmm_logger
+)
+target_link_libraries(
+  IVF_PQ_EXAMPLE PRIVATE cuvs::cuvs $<TARGET_NAME_IF_EXISTS:conda_env> rmm_logger
+)
+target_link_libraries(
+  IVF_FLAT_EXAMPLE PRIVATE cuvs::cuvs $<TARGET_NAME_IF_EXISTS:conda_env> rmm_logger
+)
+target_link_libraries(
+  VAMANA_EXAMPLE PRIVATE cuvs::cuvs $<TARGET_NAME_IF_EXISTS:conda_env> rmm_logger
+)

--- a/examples/cpp/src/benchmark_streaming_cagra.py
+++ b/examples/cpp/src/benchmark_streaming_cagra.py
@@ -1,3 +1,19 @@
+#
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import subprocess
 import math
 import re

--- a/examples/cpp/src/benchmark_streaming_cagra.py
+++ b/examples/cpp/src/benchmark_streaming_cagra.py
@@ -1,0 +1,41 @@
+import subprocess
+import math
+import re
+
+data_paths = ["../data/gist-960-euclidean/base.fbin", "../data/wiki_all_1M/base.1M.fbin"]
+query_paths = ["../data/gist-960-euclidean/query.fbin", "../data/wiki_all_1M/queries.fbin"]
+groundtruth_paths = ["../data/gist-960-euclidean/groundtruth.neighbors.ibin", "../data/wiki_all_1M/groundtruth.1M.neighbors.ibin"]
+dims = [960, 768]
+batch_data_sizes = [128000, 500000, 2000000, 8000000, 32000000, 128000000] # assuming floating point data type
+recall_pattern = r"Recall difference \(streaming CAGRA vs CAGRA\),([\d\.]+),([\d\.]+),([\d\.]+),([\d\.]+),"
+build_time_pattern = r"Build elapsed time: (\d+) milliseconds"
+
+for i in range(len(data_paths)):
+    data_path = data_paths[i]
+    query_path = query_paths[i]
+    groundtruth_path = groundtruth_paths[i]
+    dim = dims[i]
+
+    for j in range(len(batch_data_sizes)):
+        batch_data_size = batch_data_sizes[j]
+        batch_size = math.ceil(batch_data_size / dim)
+
+        # Default 20% for training with the beginning batches; pinned host memory; graph degree 32; k = 10.
+        item_str = "-p 0.2 -d " + str(data_path) + " -q " + str(query_path) + " -t " + str(groundtruth_path) + " -g 32 -k 10 " + "-b " + str(batch_size) + " -B -V"
+        try:
+            result = subprocess.run(f"./examples/cpp/build/STREAMING_CAGRA_EXAMPLE {item_str}", shell=True, capture_output=True, text=True, check=True)
+            # print(result)
+            recall_match = re.search(recall_pattern, result.stdout)
+            build_time_matches = re.findall(build_time_pattern, result.stdout)
+            if recall_match:
+                recall_values = [float(recall_match.group(i)) for i in range(1, 5)]
+            else:
+                recall_values = []
+
+            build_times = [int(time) for time in build_time_matches]
+            print("Input options,", item_str)
+            print("Recall diff values,", ', '.join(map(str, recall_values)))
+            print("Build runtimes (ms),", ', '.join(map(str, build_times)))
+
+        except subprocess.CalledProcessError as e:
+            print(f"Error occurred while running './examples/cpp/build/STREAMING_CAGRA_EXAMPLE' with argument '{item_str}': {e.stderr}")

--- a/examples/cpp/src/data_loader.cuh
+++ b/examples/cpp/src/data_loader.cuh
@@ -1,0 +1,65 @@
+#pragma once 
+
+#include <string>
+#include <fstream>
+#include <iostream>
+
+bool read_header(std::string const& data_fname, uint32_t& n_rows, uint32_t& n_cols) {
+  std::ifstream file(data_fname, std::ifstream::binary);
+  if (!file.is_open()) {
+    std::cout << "Failed to open: " << data_fname << std::endl;
+    return false;
+  }
+  file.read((char*)&n_rows, sizeof(uint32_t));
+  file.read((char*)&n_cols, sizeof(uint32_t));
+  if (file.fail()) {
+    std::cerr << "Failed to read header." << std::endl;
+    return false;
+  }
+  return true;
+}
+
+bool read_header(std::ifstream& file, uint32_t& n_rows, uint32_t& n_cols) {
+  if (!file.is_open()) {
+    std::cout << "Failed to read header." << std::endl;
+    return false;
+  }
+  file.read((char*)&n_rows, sizeof(uint32_t));
+  file.read((char*)&n_cols, sizeof(uint32_t));
+  if (file.fail()) {
+    std::cerr << "Failed to read header." << std::endl;
+    return false;
+  }
+  return true;
+}
+
+template<typename DataT>
+bool read_data(
+  std::string const& data_fname, 
+  DataT* h_data,
+  uint32_t n_rows,
+  uint32_t n_cols) {
+  if (h_data == NULL) {
+    std::cout << "Input data is not allocated" << std::endl;
+    return false;
+  }
+  std::ifstream data_file(data_fname, std::ifstream::binary);
+  if (!data_file.is_open()) {
+    std::cout << "Failed to open: " << data_fname << std::endl;
+    return false;
+  }
+  uint32_t n_rows_actual, n_cols_actual;
+  if (!read_header(data_file, n_rows_actual, n_cols_actual)) {
+    return false;
+  }
+  if (n_rows != n_rows_actual || n_cols != n_cols_actual) {
+    std::cout << "Matrix size doesn't match with the actual size" << std::endl;
+    return false;
+  }
+  if (!data_file.read((char*)h_data, n_rows * n_cols * sizeof(DataT))) {
+    std::cout << "Failed to read: " << data_fname << std::endl;
+    return false;
+  }
+
+  return true;
+}

--- a/examples/cpp/src/data_loader.cuh
+++ b/examples/cpp/src/data_loader.cuh
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once 
 
 #include <string>

--- a/examples/cpp/src/streaming_cagra_example.cu
+++ b/examples/cpp/src/streaming_cagra_example.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/cpp/src/streaming_cagra_example.cu
+++ b/examples/cpp/src/streaming_cagra_example.cu
@@ -1,0 +1,497 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <algorithm>
+#include <vector>
+#include <getopt.h>
+
+#include <raft/core/device_mdarray.hpp>
+#include <raft/core/device_resources.hpp>
+#include <raft/random/make_blobs.cuh>
+
+#include <cuvs/neighbors/cagra.hpp>
+#include <cuvs/neighbors/brute_force.hpp>
+#include <cuvs/neighbors/cagra_streaming_build.hpp>
+
+#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device/pool_memory_resource.hpp>
+#include <nvtx3/nvToolsExt.h>
+#include "common.cuh"
+#include "data_loader.cuh"
+
+#define gpuErrchk(ans) { gpuAssert((ans), __FILE__, __LINE__); }
+inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true)
+{
+   if (code != cudaSuccess) 
+   {
+      fprintf(stderr,"GPUassert: %s %s %d\n", cudaGetErrorString(code), file, line);
+      if (abort) exit(code);
+   }
+}
+
+using namespace cuvs::neighbors;
+
+// Helper function to evaluate recall.
+double calculate_recall(
+  raft::host_matrix_view<const uint32_t, int64_t> groundtruth_host, 
+  raft::host_matrix_view<const uint32_t, int64_t> neighbors_host) 
+{
+  int64_t max_k = groundtruth_host.extent(1);
+  int64_t k = neighbors_host.extent(1);
+  if (groundtruth_host.extent(0) != neighbors_host.extent(0) || max_k < k) {
+      return -1;
+  }
+  const uint32_t* groundtruth_neighbor_ptr = groundtruth_host.data_handle();
+  const uint32_t* neighbor_ptr = neighbors_host.data_handle();
+
+  // Borrowed from https://github.com/rapidsai/cuvs/blob/branch-24.10/cpp/bench/ann/src/common/benchmark.hpp#L342
+  std::size_t n_queries = groundtruth_host.extent(0);
+  std::size_t match_count = 0;
+  std::size_t total_count = n_queries * static_cast<size_t>(k);
+
+  // We go through the groundtruth with same stride as the benchmark loop.
+  for (std::size_t i = 0; i < n_queries; i++) {
+    for (std::uint32_t j = 0; j < k; j++) {
+      auto act_idx = neighbor_ptr[i * k + j];
+      for (std::uint32_t l = 0; l < k; l++) {
+        auto exp_idx = groundtruth_neighbor_ptr[i * max_k + l];
+        if (act_idx == exp_idx) {
+          match_count++;
+          break;
+        }
+      }
+    }
+  }
+  return static_cast<double>(match_count) / static_cast<double>(total_count);
+} 
+
+// Helper function for CAGRA search.
+void search_helper(
+  raft::device_resources const& dev_resources, 
+  const std::list<size_t>& itopk_list,
+  std::vector<float>& recall_res,
+  const cuvs::neighbors::cagra::index<float, uint32_t>& index,
+  raft::host_matrix_view<const float, int64_t> query_host,
+  raft::host_matrix_view<const uint32_t, int64_t> groundtruth_host, 
+  const int64_t topk,
+  const bool verbose)
+{
+  // Creating device query set, neighbor array, distance array, as well as host neighbor array.
+  int64_t n_queries = query_host.extent(0);
+  int64_t n_dim = query_host.extent(1);
+  auto query_device = raft::make_device_matrix<float>(dev_resources, n_queries, n_dim);
+  auto neighbors_device = raft::make_device_matrix<uint32_t>(dev_resources, n_queries, topk);
+  auto distances_device = raft::make_device_matrix<float>(dev_resources, n_queries, topk);
+  auto neighbors_host = raft::make_host_matrix<uint32_t>(n_queries, topk);
+
+  // Copying query from host matrix to device matrix. 
+  raft::copy(query_device.data_handle(), query_host.data_handle(), query_host.size(), raft::resource::get_cuda_stream(dev_resources));  
+
+  cagra::search_params search_params;
+  search_params.max_iterations = 512;
+  search_params.search_width = 8;
+  if (verbose) {
+    std::cout << "itopk,recall" << std::endl;
+  }
+  for (auto it = itopk_list.begin(); it != itopk_list.end(); ++it) {
+    search_params.itopk_size = *it; 
+    cagra::search(dev_resources, search_params, index, query_device.view(), neighbors_device.view(), distances_device.view());
+    // Copying neighbors back to host for recall computation. 
+    raft::copy(neighbors_host.data_handle(), neighbors_device.data_handle(), neighbors_device.size(), raft::resource::get_cuda_stream(dev_resources));  
+    double recall = calculate_recall(groundtruth_host, neighbors_host.view());
+    if (verbose) {
+      std::cout << search_params.itopk_size << "," << recall << std::endl;  
+    }
+    recall_res.push_back(recall);
+  }
+}
+
+// Normal CAGRA index build.
+void baseline_build_search(
+  raft::device_resources const& dev_resources, 
+  const std::list<size_t>& itopk_list,
+  std::vector<float>& recall_res,
+  raft::host_matrix_view<const float, int64_t> dataset, 
+  raft::host_matrix_view<const float, int64_t> query, 
+  raft::host_matrix_view<const uint32_t, int64_t> groundtruth, 
+  cagra::index_params& index_params, 
+  const int64_t topk, 
+  const bool verbose) 
+{
+  std::cout << "Building baseline CAGRA index" << std::endl;
+  auto pq_params = cagra::graph_build_params::ivf_pq_params(dataset.extents(), cuvs::distance::DistanceType::L2Expanded);
+  // Disable refinement and using IVF-PQ KNN construction to match streaming CAGRA build.
+  pq_params.refinement_rate = 1;
+  index_params.attach_dataset_on_build = false;
+  index_params.graph_build_params = pq_params;
+  auto start = std::chrono::high_resolution_clock::now();
+  auto index = cagra::build(dev_resources, index_params, dataset);
+  auto end = std::chrono::high_resolution_clock::now();
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  std::cout << "Build elapsed time: " << elapsed.count() << " milliseconds\n";
+
+  index.update_dataset(dev_resources, raft::make_const_mdspan(dataset));
+  if (verbose) {
+    std::cout << "CAGRA index has " << index.size() << " vectors" << std::endl;
+    std::cout << "CAGRA graph has degree " << index.graph_degree() << ", graph size ["
+              << index.graph().extent(0) << ", " << index.graph().extent(1) << "]" << std::endl;
+    std::cout << "Searching baseline CAGRA index" << std::endl;
+  }
+  search_helper(dev_resources, itopk_list, recall_res, index, query, groundtruth, topk, verbose);
+}
+
+// Streaming CAGRA index build.
+void streaming_build_search(
+  raft::device_resources const& dev_resources, 
+  const std::list<size_t>& itopk_list,
+  std::vector<float>& recall_res,
+  raft::host_matrix_view<const float, int64_t> dataset, 
+  raft::host_matrix_view<const float, int64_t> query, 
+  raft::host_matrix_view<const uint32_t, int64_t> groundtruth, 
+  cagra::index_params& index_params, 
+  const int64_t topk, 
+  const int64_t streaming_batch_size, 
+  const float kmeans_percentage, 
+  const bool train_kmeans_with_beginning_batches,
+  const bool verbose)
+{
+  std::cout << "Streaming building CAGRA index" << std::endl;
+  int64_t num_dim = dataset.extent(1);
+  int64_t num_batch = ceil(1.0 * dataset.extent(0) / streaming_batch_size);
+  int64_t num_sampled_batch = ceil(kmeans_percentage * num_batch);
+  // Only CAGRA graph output is needed.
+  index_params.attach_dataset_on_build = false;
+  // IVF-PQ KNN construction is required for streaming build.
+  auto pq_params = cagra::graph_build_params::ivf_pq_params(dataset.extents(), cuvs::distance::DistanceType::L2Expanded);
+  // Refinement rate=1 is required for streaming build. 
+  pq_params.refinement_rate = 1;
+  index_params.graph_build_params = pq_params;
+  // Decide which batches to use for IVF-PQ index building. Either using beginning batches or random batches.
+  std::set<int> selected_batches;
+  if (train_kmeans_with_beginning_batches) {
+    for (int i = 0; i < num_sampled_batch; ++i) {
+      selected_batches.insert(i);
+    }
+  } else {
+    std::random_device rd; 
+    std::mt19937 g(12345);
+    std::uniform_int_distribution<> dist(0, num_batch - 1);
+    while (selected_batches.size() < num_sampled_batch) {
+      int batch_id = dist(g);
+      selected_batches.insert(batch_id);
+    }
+  }
+  
+  if (verbose) {
+    std::cout << "Batch size for streaming build: " << streaming_batch_size << std::endl; 
+    std::cout << "Number of batches: " << num_batch << std::endl; 
+    std::cout << "Batch ids used for building IVF-PQ: "; 
+    for (const auto& id : selected_batches) {
+      std::cout << id << " ";
+    }
+    std::cout << std::endl;
+  }
+
+  auto start = std::chrono::high_resolution_clock::now();
+  nvtxRangePush("StreamingCAGRA_construction");
+  cuvs::neighbors::cagra_streaming_build<float, uint32_t> test(dev_resources, dataset.extent(0), num_dim, 
+    num_sampled_batch, streaming_batch_size, index_params, false);
+  nvtxRangePop();
+
+  for (int i = 0; i < num_batch; i++) {
+    nvtxRangePush("StreamingCAGRA_process_batch");
+    int64_t curr_batch_size = std::min(streaming_batch_size, (int64_t)dataset.extent(0) - i * streaming_batch_size);
+    auto curr_dataset = raft::make_host_matrix_view<const float, int64_t>(dataset.data_handle() + i * streaming_batch_size * num_dim, curr_batch_size, num_dim);
+    if (selected_batches.find(i) != selected_batches.end()) {
+      // Sampled batches for IVF-PQ index building.
+      test.process_batch(dev_resources, index_params, curr_dataset, true, true);
+    } else {
+      // Non-sampled batches.
+      test.process_batch(dev_resources, index_params, curr_dataset, false, false);
+    }
+    nvtxRangePop();
+  }
+  auto end_add_batch = std::chrono::high_resolution_clock::now();
+  // Finialize the graph building process.
+  nvtxRangePush("StreamingCAGRA_finalize_graph");
+  auto index = test.finalize_graph(dev_resources, index_params);
+  nvtxRangePop();
+  auto end = std::chrono::high_resolution_clock::now();
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  std::cout << "Build elapsed time: " << elapsed.count() << " milliseconds\n";
+  auto elapsed_add_batch = std::chrono::duration_cast<std::chrono::milliseconds>(end_add_batch - start);
+  std::cout << "Adding batch elapsed time: " << elapsed_add_batch.count() << " milliseconds\n";
+
+  // Update dataset is required before search. However, if the user only needs CAGRA graph, it's already returned in index. No need to update dataset.  
+  index.update_dataset(dev_resources, raft::make_const_mdspan(dataset));
+  if (verbose) {
+    std::cout << "CAGRA index has " << index.size() << " vectors" << std::endl;
+    std::cout << "CAGRA graph has degree " << index.graph_degree() << ", graph size ["
+              << index.graph().extent(0) << ", " << index.graph().extent(1) << "]" << std::endl;
+    std::cout << "Searching baseline CAGRA index" << std::endl;
+  }
+  search_helper(dev_resources, itopk_list, recall_res, index, query, groundtruth, topk, verbose);
+}
+
+void print_helper(const struct option* longOptions) {
+  const char* descriptions[] = {
+    "Path to dataset file (string)",
+    "Path to query file (string)",
+    "Path to groundtruth file (string)",
+    "CAGRA graph degree (int)",
+    "Streaming build batch size (int)",
+    "Top-K (int)",
+    "Streaming build k-means training percentage (float)",
+    "Enable data permutation for streaming build (bool)",
+    "Skip baseline CAGRA build (bool)",
+    "Streaming build train kmeans with beginning batches (bool)",
+    "Allocation with host pinned memory (bool)",
+    "Verbose (bool)",
+    "Show this help message"
+  };
+
+  std::cout << "Usage: STREAMING_CAGRA_EXAMPLE [OPTIONS]\n";
+  std::cout << "Options:\n";
+
+  for (int i = 0; longOptions[i].name != 0; ++i) {
+    std::cout << "  -" << (char)longOptions[i].val << ", --" << longOptions[i].name;
+    if (longOptions[i].has_arg == required_argument) {
+        std::cout << " <arg>";
+    }
+    std::cout << "    " << descriptions[i] << std::endl;
+  }
+}
+
+int main(int argc, char* argv[]) 
+{
+  std::string dataset_fname = "../data/sift-128-euclidean/base.fbin";
+  std::string query_fname = "../data/sift-128-euclidean/query.fbin";
+  std::string groundtruth_fname = "../data/sift-128-euclidean/groundtruth.neighbors.ibin";
+  int64_t topk = 10;
+  int64_t graph_degree = 32;
+  int64_t streaming_batch_size = 100'000;
+  float kmeans_percentage = 0.2;
+  bool skip_baseline = false;
+  bool data_permutation = false;
+  bool train_kmeans_with_beginning_batches = false;
+  bool verbose = false;
+  bool allocate_pinned = false;
+
+  struct option longOptions[] = {
+    {"dataset", required_argument, 0, 'd'},
+    {"query", required_argument, 0, 'q'},
+    {"groundtruth", required_argument, 0, 't'},
+    {"graph_degree", required_argument, 0, 'g'},
+    {"streaming_batch_size", required_argument, 0, 'b'},
+    {"topk", required_argument, 0, 'k'},
+    {"kmeans_percentage", required_argument, 0, 'p'},
+    {"data_permutation", no_argument, 0, 'P'},
+    {"skip_baseline", no_argument, 0, 'S'},
+    {"train_kmeans_with_beginning_batches", no_argument, 0, 'B'},
+    {"allocate_pinned", no_argument, 0, 'I'},
+    {"verbose", no_argument, 0, 'V'},
+    {"help", no_argument, 0, 'h'},
+    {0, 0, 0, 0} // Terminating zeroed out element
+  };
+
+  int optionIndex = 0;
+  int opt;
+  while ((opt = getopt_long(argc, argv, "d:q:t:g:b:k:p:PSBIVh", longOptions, &optionIndex)) != -1) {
+    switch (opt) {
+      case 'd':
+        dataset_fname = optarg;
+        break;
+      case 'q':
+        query_fname = optarg;
+        break;
+      case 't':
+        groundtruth_fname = optarg;
+        break;
+      case 'g':
+        graph_degree = std::atol(optarg);
+        break;
+      case 'b':
+        streaming_batch_size = std::atol(optarg);
+        break;
+      case 'k':
+        topk = std::atol(optarg);
+        break;
+      case 'p':
+        kmeans_percentage = std::atof(optarg);
+        break;
+      case 'P':
+        data_permutation = true;
+        break;
+      case 'S':
+        skip_baseline = true;
+        break;
+      case 'B':
+        train_kmeans_with_beginning_batches = true;
+        break;
+      case 'I':
+        allocate_pinned = true;
+        break;
+      case 'V':
+        verbose = true; 
+        break; 
+      case 'h':
+        print_helper(longOptions);
+        return 0; 
+      default:
+        std::cerr << "Invalid option!" << std::endl;
+        return 1;
+    }
+  }
+
+  if (verbose) {
+    std::cout << "Path to dataset file: " << dataset_fname << std::endl;
+    std::cout << "Path to query file: " << query_fname << std::endl;
+    std::cout << "Path to groundtruth file: " << groundtruth_fname << std::endl;
+    std::cout << "CAGRA graph degree: " << graph_degree << std::endl;
+    std::cout << "Streaming build batch size: " << streaming_batch_size << std::endl;
+    std::cout << "Top-K: " << topk << std::endl;
+    std::cout << "Streaming build k-means training percentage: " << kmeans_percentage << std::endl;
+    std::cout << "Enable data permutation for streaming build: " << (data_permutation ? "True" : "False") << std::endl;
+    std::cout << "Streaming build train kmeans with beginning batches: " << (train_kmeans_with_beginning_batches ? "True" : "False") << std::endl;
+    std::cout << "Skip running baseline CAGRA build: " << (skip_baseline ? "True" : "False") << std::endl;
+    std::cout << "Allocation with host pinned memory: " << (allocate_pinned ? "True" : "False") << std::endl;
+  }
+
+  uint32_t n_samples, n_queries, n_dim, max_k; 
+  read_header(dataset_fname, n_samples, n_dim);
+  read_header(query_fname, n_queries, n_dim);
+  read_header(groundtruth_fname, n_queries, max_k);
+  size_t dataset_size = (size_t)n_samples * (size_t)n_dim * sizeof(float);
+  size_t query_size = (size_t)n_queries * (size_t)n_dim * sizeof(float);
+  size_t groundtruth_size = (size_t)n_queries * (size_t)max_k * sizeof(uint32_t);
+
+  raft::device_resources dev_resources;
+  // Set pool memory resource with 40GiB initial pool size. All allocations use the same pool.
+  raft::resource::set_workspace_to_pool_resource(dev_resources, 40 * 1024 * 1024 * 1024ull);
+
+  float *dataset = nullptr;
+  float *query = nullptr;
+  uint32_t *groundtruth = nullptr;
+
+  if (allocate_pinned) {
+    gpuErrchk(cudaMallocHost((void**)&dataset, dataset_size));
+    gpuErrchk(cudaMallocHost((void**)&query, query_size));
+    gpuErrchk(cudaMallocHost((void**)&groundtruth, groundtruth_size));
+  } else {
+    dataset = (float*)malloc(dataset_size);
+    query = (float*)malloc(query_size);
+    groundtruth = (uint32_t*)malloc(groundtruth_size);
+  }
+
+  bool success =  read_data(dataset_fname, dataset, n_samples, n_dim) && 
+                  read_data(query_fname, query, n_queries, n_dim) &&
+                  read_data(groundtruth_fname, groundtruth, n_queries, max_k);
+  if (!success) {
+    std::cout << "Data reading failed.\n";
+    exit(1);
+  }
+
+  cagra::index_params index_params;
+  index_params.graph_degree = graph_degree; 
+  index_params.intermediate_graph_degree = graph_degree * 2;
+
+  std::list<size_t> itopk_list = {16, 32, 64, 128, 256, 512};
+  std::vector<float> recall_baseline; 
+  std::vector<float> recall_streaming; 
+
+  if (data_permutation) {
+    // Permutation to make sure the dataset is not ordered. 
+    float *dataset_permu = nullptr;
+    uint32_t *groundtruth_permu = nullptr;
+    if (allocate_pinned) {
+      gpuErrchk(cudaMallocHost((void**)&dataset_permu, dataset_size));
+      gpuErrchk(cudaMallocHost((void**)&groundtruth_permu, groundtruth_size));
+    } else {
+      dataset_permu = (float*)malloc(dataset_size);
+      groundtruth_permu = (uint32_t*)malloc(groundtruth_size);
+    }
+    
+    std::vector<size_t> permutation_idx(n_samples);
+    // Fill in numbers from 0 to dataset.extent(0)-1 and then generate permutation indices by randomly shuflle the array. 
+    std::iota(permutation_idx.begin(), permutation_idx.end(), 0); 
+    std::mt19937 g(12345);
+    std::shuffle(permutation_idx.begin(), permutation_idx.end(), g);
+    // Copy data to the permutated location. 
+    for (int64_t i = 0; i < n_samples; i++) {
+      int64_t out_loc = permutation_idx[i];
+      for (int64_t j = 0; j < n_dim; j++) { 
+        dataset_permu[out_loc * n_dim + j] = dataset[i * n_dim + j];
+      }
+    }
+    // Reassign groundtruth neighbors.
+    for (int64_t i = 0; i < n_queries; i++) {
+      for (int64_t j = 0; j < max_k; j++) {
+        groundtruth_permu[i * max_k + j] = permutation_idx[groundtruth[i * max_k + j]];
+      }
+    }
+
+    std::swap(dataset_permu, dataset);
+    std::swap(groundtruth_permu, groundtruth);
+
+    if (allocate_pinned) {
+      gpuErrchk(cudaFreeHost(dataset_permu));
+      gpuErrchk(cudaFreeHost(groundtruth_permu));
+    } else {
+      free(dataset_permu);
+      free(groundtruth_permu);
+    }
+  }
+
+  auto dataset_view = raft::make_host_matrix_view<float, int64_t>(dataset, n_samples, n_dim);
+  auto query_view = raft::make_host_matrix_view<float, int64_t>(query, n_queries, n_dim);
+  auto groundtruth_view = raft::make_host_matrix_view<uint32_t, int64_t>(groundtruth, n_queries, max_k);
+
+  if (!skip_baseline) {
+    baseline_build_search(dev_resources, itopk_list, recall_baseline, dataset_view, 
+    query_view, 
+    groundtruth_view, 
+    index_params, topk, verbose);
+  }
+
+  streaming_build_search(
+    dev_resources, 
+    itopk_list, recall_streaming,
+    dataset_view, 
+    query_view, 
+    groundtruth_view, 
+    index_params, topk, streaming_batch_size, kmeans_percentage, train_kmeans_with_beginning_batches, verbose);
+  
+  if (!skip_baseline) {
+    std::cout << "Recall difference (streaming CAGRA vs CAGRA),";
+    for (int64_t i = 0; i < recall_baseline.size(); i++) {
+      std::cout << recall_streaming[i] / recall_baseline[i] << ",";
+    }
+    std::cout << std::endl;
+  }
+
+  if (allocate_pinned) {
+    gpuErrchk(cudaFreeHost(dataset));
+    gpuErrchk(cudaFreeHost(groundtruth));
+    gpuErrchk(cudaFreeHost(query));
+  } else {
+    free(dataset);
+    free(groundtruth);
+    free(query);
+  }
+
+  return 0; 
+}


### PR DESCRIPTION
There are instances where the user's raw data for building the CAGRA index is not stored in a contiguous memory space on the host. Instead, the data is organized into batches, with these batches becoming available at different timestamps. Consequently, a streamed CAGRA index build is preferred due to the following advantages:

1. **Early Index Building**: The CAGRA index construction can begin as soon as a few batches of the dataset are available, rather than waiting for all data batches to be ready. Note that this is only supported with IVF-PQ KNNG construction method.
2. **Memory Efficiency**: If the dataset is not required in the resulting CAGRA index (e.g., when the CAGRA index is later converted to an HNSW index for search) and the refinement is disabled in IVF-PQ KNNG construction, a streamed CAGRA build eliminates the need for a contiguous memory space for the entire dataset. This approach saves memory and avoids an unnecessary data copy.

This PR introduces the support for a streamed CAGRA index build. The whole CAGRA index build with IVF-PQ for base KNNG construction could be divided as four steps

* Step 1: IVF-PQ index building on sampled data batches. This step requires a _sampled dataset_ and can begin once a sufficient number of sample batches (usually 20% of the entire dataset) are available for k-means clustering.
* Step 2: Adding all vectors in the dataset into the IVF-PQ index. This step requires the _whole dataset which does not need to be contiguous_. Data batches can be added either after building the IVF-PQ index on the sampled batches or during the API call for other batches.
* Step 3: IVF-PQ search to build kNN graph with refinement disabled. This step requires the _whole dataset which does not need to be contiguous_. This step begins once all data batches have been added to the IVF-PQ index. Data batches are processed sequentially for the search. 
* Step 4: CAGRA graph optimization. This step does not require the input dataset.

This POC implements step 1 and step 2 in the `process_batch` call and step 3 and step 4 in the `finialize_graph` call. Users should call `process_batch` after a new batch is available and `finialize_graph` after all the batches are processed. During `process_batch` call, the pointers to the data batches are stored internally, and users must ensure these data pointers remain accessible until all the data batches are processed. `process_batch` takes two boolean values which indicate (1) whether the batch is part of the sampled batches (i.e., the batches used for IVF-PQ index building), and (2) whether to add the batch to the IVF-PQ index if it's a sampled batch. Users also need to pass in information such as the max batch size, the number of sampled batches, CAGRA index parameters, etc., though the `cagra_streaming_build` constructor.

Here is an usage example 

```
int64_t num_sampled_batch = 2;
int64_t batch_size = 100000;
cuvs::neighbors::cagra_streaming_build<float, uint32_t> test(dev_resources, dataset.extent(0), num_dim, num_sampled_batch, batch_size, index_params);

// Sample batch but not adding to the graph 
test.process_batch(dev_resources, index_params, curr_dataset, true, false);
// Sample batch and adding to the graph 
test.process_batch(dev_resources, index_params, curr_dataset, true, true);
// Not a sample batch 
test.process_batch(dev_resources, index_params, curr_dataset, false, false);
… // Adding all batches 
… 

auto index = test.finialize_graph(dev_resources, index_params);
```
